### PR TITLE
build_tools/build_boost.sh: add cxxstd=14

### DIFF
--- a/build_tools/build-boost.sh
+++ b/build_tools/build-boost.sh
@@ -679,6 +679,7 @@ EOF
         threading=multi \
         target-os=android \
         binary-format=elf \
+        cxxstd=14 \
         address-model=$BJAMADDRMODEL \
         architecture=$BJAMARCH \
         abi=$BJAMABI \


### PR DESCRIPTION
Boost 1.68 using the Android NDK 17.2 failed to build. Failures
appeared as an undefined reference to
boost::system::detail::generic_category_instance in
include/boost/system/error_code.hpp:477.  A Boost issue indicated that
this was due to incompatible cxx feature settings (see
https://github.com/boostorg/system/issues/26#issuecomment-413627799).
This commit adds cxxstd=14  to the b2 call.