### PR TITLE
example_app/app/build.gradle: remove flag setting c++14

### DIFF
--- a/example_app/app/build.gradle
+++ b/example_app/app/build.gradle
@@ -19,7 +19,9 @@ android {
         externalNativeBuild {
             cmake {
                 // flags for the c++ compiler eg "-std=c++14 -frtti -fexceptions"
-                cppFlags "-std=c++14"
+                // If you set cppFlags to "-std=c++14", you may need to build your boost libraries
+                // with the same flags, depending on your compiler defaults.
+                // cppFlags "-std=c++14"
 
                 // this causes libc++_shared.so to get packaged into .apk
                 arguments '-DANDROID_STL=c++_shared'


### PR DESCRIPTION
If we force cppFlags "-std=c++14" in the app, some compilers (Mac NDK
17.2 for instance) fail to link if the boost libraries were not also
built with the same language level set.  This removes the explicit
setting in the example app so both the boost libraries and the
example app use the default.