### PR TITLE
Boost_For_Android_With_Bzip

### DIFF
--- a/__build.sh
+++ b/__build.sh
@@ -343,6 +343,13 @@ for LINKAGE in $LINKAGES; do
         export BFA_TOOL_TRIPLE_FOR_ABI="$(tool_triple_for_abi_name $ABI_NAME)"
         export BFA_COMPILER_FLAGS_FOR_ABI="$(compiler_flags_for_abi_name $ABI_NAME)"
         export BFA_LINKER_FLAGS_FOR_ABI="$(linker_flags_for_abi_name $ABI_NAME)"
+		
+		#Export bzip2source for boost build if present
+		if [ ! -z "$BZIP2_SOURCES_PATH" ]; 
+		then
+			echo "Exporting bzip source for boost build"
+			export BZIP2_SOURCE=$BZIP2_SOURCES_PATH
+		fi
         
         echo "------------------------------------------------------------"| tee -a ${LOG_FILE}
         echo "Building boost for: $ABI_NAME $LINKAGE on host ${HOST_OS_TAG}" | tee -a ${LOG_FILE}
@@ -377,6 +384,7 @@ for LINKAGE in $LINKAGES; do
                 abi=$abi    \
                 link=$LINKAGE                  \
                 threading=multi              \
+				visibility=$BOOST_LIB_VISIBILITY \
                 target-os=android           \
                 --user-config=$USER_CONFIG_FILE \
                 --ignore-site-config         \

--- a/do.sh
+++ b/do.sh
@@ -24,6 +24,11 @@ export ABI_NAMES="arm64-v8a armeabi-v7a x86 x86_64"
 # Whether to build boost as dynamic or shared libraries (or both)
 export LINKAGES="" #shared static" # can be "shared" or "static" or "shared static" (both)
 
+#For building boost with bzip2 sources
+export BZIP2_SOURCES_PATH=$(pwd)/../../bzip/bzip2-master #path to bzip sources, in this you would have to create bz_version.h(in actual source this file will be present as bz_version.h.in template and in bzip cmake build this will be created)
+#But for b2 build you need to create this file manually, just rename bz_version.h.in to bz_version.h
+export BOOST_LIB_VISIBILITY="global" #possible values - global, protected, hidden.(https://www.boost.org/doc/libs/1_73_0/tools/build/doc/html/index.html#bbv2.builtin.features.visibility)
+#The visibility should be set to global because boost_iostreams depends on symbols exported by bzip and if visibility is not set to global then all libs will be generated with hidden visiblity and boost_iostreams will fail in runtime saying not able to find "BZ2_bz..." symbol.
 
 #----------------------------------------------------------------
 


### PR DESCRIPTION
Fix for issue:
https://github.com/dec1/Boost-for-Android/issues/28 Changes:
+ Added bzip2 sources to boost build and also changes to set global visibility for boost built libraries.